### PR TITLE
Added initialization to sessions

### DIFF
--- a/client/js/pages/sessions/add.js
+++ b/client/js/pages/sessions/add.js
@@ -7,6 +7,10 @@ var _ = require('../../helpers/underscore')
 module.exports = PageView.extend({
   pageTitle: 'Add session',
   template: templates.pages.sessions.add,
+  initialize: function () {
+    app.speakers.fetch({ data: { event: app.me.selectedEvent } })
+    app.companies.fetch({ data: { event: app.me.selectedEvent } })
+  },
   subviews: {
     form: {
       container: 'form',


### PR DESCRIPTION
Users couldn't add a Speaker or Company to a Session if they were not the app's cache.
Added an initialisation method to fix this.